### PR TITLE
Support for Reliable Recipe Viewer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,17 @@ repositories {
 			excludeGroup "io.github.fabricators_of_create"
 		}
 	}
+	exclusiveContent {
+		forRepository {
+			maven {
+				name = "Cassian's Maven"
+				url = uri("https://maven.cassian.cc")
+			}
+		}
+		filter {
+			includeGroupAndSubgroups("cc.cassian")
+		}
+	}
 }
 
 loom {
@@ -71,7 +82,10 @@ dependencies {
 
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.2.0-beta.10")))
-	modImplementation "maven.modrinth:eiv:${eiv_version}+${minecraft_version}"
+	modImplementation("cc.cassian.rrv:reliable-recipe-viewer-fabric:${project.rrv_version}+${minecraft_version}") {
+		transitive = false
+	}
+	modCompileOnly "maven.modrinth:eiv:${eiv_version}+${minecraft_version}"
 	modImplementation "vectorwing:FarmersDelight:${fdrf_version}+refabricated"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.parallel=true
 
 minecraft_version=1.21.10
 yarn_mappings=1.21.10+build.2
-loader_version=0.17.3
-loom_version=1.13-SNAPSHOT
+loader_version=0.18.4
+loom_version=1.14-SNAPSHOT
 
 # Mod Properties
 mod_version=1.1.3-1.21.10
@@ -14,4 +14,5 @@ archives_base_name=mintyblends
 # Dependencies
 fabric_version=0.138.3+1.21.10
 eiv_version=5.2.0
+rrv_version=6.0.1
 fdrf_version=1.21.10-3.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ archives_base_name=mintyblends
 # Dependencies
 fabric_version=0.138.3+1.21.10
 eiv_version=5.2.0
-rrv_version=6.0.1
+rrv_version=6.0.2
 fdrf_version=1.21.10-3.4.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/io/github/mintynoura/mintyblends/MintyBlendsClient.java
+++ b/src/client/java/io/github/mintynoura/mintyblends/MintyBlendsClient.java
@@ -2,6 +2,7 @@ package io.github.mintynoura.mintyblends;
 
 import io.github.mintynoura.mintyblends.block.HortensiaCropBlock;
 import io.github.mintynoura.mintyblends.compat.eiv.EivClientIntegration;
+import io.github.mintynoura.mintyblends.compat.rrv.RrvClientIntegration;
 import io.github.mintynoura.mintyblends.particle.KettleSteamParticle;
 import io.github.mintynoura.mintyblends.registry.ModBlocks;
 import io.github.mintynoura.mintyblends.registry.ModParticleTypes;
@@ -65,6 +66,9 @@ public class MintyBlendsClient implements ClientModInitializer {
 
 		if (FabricLoader.getInstance().isModLoaded("eiv")) {
 			EivClientIntegration.onIntegrationInitialize();
+		}
+		if (FabricLoader.getInstance().isModLoaded("rrv")) {
+			RrvClientIntegration.onIntegrationInitialize();
 		}
 	}
 }

--- a/src/client/java/io/github/mintynoura/mintyblends/compat/rrv/KettleBrewingClientRecipe.java
+++ b/src/client/java/io/github/mintynoura/mintyblends/compat/rrv/KettleBrewingClientRecipe.java
@@ -1,0 +1,97 @@
+package io.github.mintynoura.mintyblends.compat.rrv;
+
+import cc.cassian.rrv.api.recipe.ReliableClientRecipe;
+import cc.cassian.rrv.api.recipe.ReliableClientRecipeType;
+import cc.cassian.rrv.common.recipe.inventory.RecipeViewMenu;
+import cc.cassian.rrv.common.recipe.inventory.RecipeViewScreen;
+import cc.cassian.rrv.common.recipe.inventory.SlotContent;
+import cc.cassian.rrv.common.recipe.rendering.AnimationTicker;
+import io.github.mintynoura.mintyblends.MintyBlends;
+import io.github.mintynoura.mintyblends.screen.KettleScreen;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.util.Identifier;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class KettleBrewingClientRecipe implements ReliableClientRecipe {
+
+    private static final Identifier PROGRESS_TEXTURE = Identifier.of(MintyBlends.MOD_ID, "textures/gui/sprites/container/kettle/progress.png");
+
+    private final List<SlotContent> ingredients;
+    private final SlotContent container;
+    private final SlotContent result;
+    private final int brewingTime;
+    private final AnimationTicker brewingTicker;
+
+
+    public KettleBrewingClientRecipe(KettleBrewingServerRecipe serverRecipe) {
+        this.ingredients = new ArrayList<>();
+
+        serverRecipe.getIngredients().forEach(ingredient ->
+                ingredients.add(SlotContent.of(ingredient)));
+
+        this.container = SlotContent.of(serverRecipe.getContainer());
+        this.result = SlotContent.of(serverRecipe.getResult());
+        this.brewingTime = serverRecipe.getBrewingTime();
+
+        this.brewingTicker = AnimationTicker.create(Identifier.of(MintyBlends.MOD_ID, "brewing_ticker"), this.brewingTime);
+    }
+
+    @Override
+    public ReliableClientRecipeType getViewType() {
+        return KettleBrewingClientRecipeType.INSTANCE;
+    }
+
+    @Override
+    public void bindSlots(RecipeViewMenu.SlotFillContext slotFillContext) {
+        for (int i = 0; i < ingredients.size() && i < this.getViewType().getSlotCount() - 1; i++) {
+            slotFillContext.bindSlot(i, ingredients.get(i));
+        }
+
+        slotFillContext.bindSlot(4, container);
+        slotFillContext.bindSlot(5, result);
+    }
+
+    @Override
+    public List<SlotContent> getIngredients() {
+        return this.ingredients;
+    }
+
+    @Override
+    public List<SlotContent> getResults() {
+        return List.of(this.result);
+    }
+
+    @Override
+    public List<AnimationTicker> getAnimationTickers() {
+        return List.of(this.brewingTicker);
+    }
+
+    @Override
+    public void renderRecipe(RecipeViewScreen screen, RecipePosition recipePosition, DrawContext guiGraphics, int mouseX, int mouseY, float partialTicks) {
+        int brewProgress = Math.round(this.brewingTicker.getProgress() * 24.0F);
+        guiGraphics.drawTexture(RenderPipelines.GUI_TEXTURED, PROGRESS_TEXTURE, 77, 20, 0, 0, brewProgress, 16, 24, 16);
+    }
+
+    @Override
+    public boolean supportsItemTransfer() {
+        return true;
+    }
+
+    @Override
+    public List<Class<? extends HandledScreen<?>>> getTransferClasses() {
+        return Collections.singletonList(KettleScreen.class);
+    }
+
+    @Override
+    public void mapRecipeItems(RecipeTransferMap transferMap, HandledScreen<?> screen) {
+        for (int i = 0; i < this.ingredients.size() && i < this.getViewType().getSlotCount() - 1; i++) {
+            transferMap.linkSlots(i, i);
+        }
+        transferMap.linkSlots(4, 4);
+    }
+}

--- a/src/client/java/io/github/mintynoura/mintyblends/compat/rrv/KettleBrewingClientRecipeType.java
+++ b/src/client/java/io/github/mintynoura/mintyblends/compat/rrv/KettleBrewingClientRecipeType.java
@@ -1,0 +1,69 @@
+package io.github.mintynoura.mintyblends.compat.rrv;
+
+import cc.cassian.rrv.api.recipe.ReliableClientRecipeType;
+import cc.cassian.rrv.common.recipe.inventory.RecipeViewMenu;
+import io.github.mintynoura.mintyblends.MintyBlends;
+import io.github.mintynoura.mintyblends.registry.ModBlocks;
+import io.github.mintynoura.mintyblends.registry.ModItems;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public class KettleBrewingClientRecipeType implements ReliableClientRecipeType {
+
+    public static final ReliableClientRecipeType INSTANCE = new KettleBrewingClientRecipeType();
+
+    @Override
+    public Text getDisplayName() {
+        return Text.translatableWithFallback("recipe.mintyblends.kettle_brewing", "Kettle Brewing");
+    }
+
+    @Override
+    public int getDisplayWidth() {
+        return 133;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 61;
+    }
+
+    @Override
+    public Identifier getGuiTexture() {
+        return Identifier.of(MintyBlends.MOD_ID, "textures/gui/eiv/kettle.png");
+    }
+
+    @Override
+    public int getSlotCount() {
+        return 6;
+    }
+
+    @Override
+    public void placeSlots(RecipeViewMenu.SlotDefinition slotDefinition) {
+        slotDefinition.addItemSlot(0, 29, 12);
+        slotDefinition.addItemSlot(1, 47, 12);
+        slotDefinition.addItemSlot(2, 29, 30);
+        slotDefinition.addItemSlot(3, 47, 30);
+        // container here
+        slotDefinition.addItemSlot(4, 112, 21);
+        // result here
+        slotDefinition.addItemSlot(5, 1, 2);
+    }
+
+    @Override
+    public Identifier getId() {
+        return Identifier.of(MintyBlends.MOD_ID, "kettle_brewing");
+    }
+
+    @Override
+    public ItemStack getIcon() {
+        return new ItemStack(ModBlocks.KETTLE);
+    }
+
+    @Override
+    public List<ItemStack> getCraftReferences() {
+        return List.of(new ItemStack(ModBlocks.KETTLE), new ItemStack(ModItems.HERBAL_BREW));
+    }
+}

--- a/src/client/java/io/github/mintynoura/mintyblends/compat/rrv/RrvClientIntegration.java
+++ b/src/client/java/io/github/mintynoura/mintyblends/compat/rrv/RrvClientIntegration.java
@@ -1,0 +1,11 @@
+package io.github.mintynoura.mintyblends.compat.rrv;
+
+import cc.cassian.rrv.api.recipe.ItemView;
+
+import java.util.Collections;
+
+public class RrvClientIntegration {
+    public static void onIntegrationInitialize() {
+        ItemView.registerClientRecipeWrapper(KettleBrewingServerRecipe.TYPE, serverRecipe -> Collections.singletonList(new KettleBrewingClientRecipe(serverRecipe)));
+    }
+}

--- a/src/main/java/io/github/mintynoura/mintyblends/compat/rrv/KettleBrewingServerRecipe.java
+++ b/src/main/java/io/github/mintynoura/mintyblends/compat/rrv/KettleBrewingServerRecipe.java
@@ -1,0 +1,68 @@
+package io.github.mintynoura.mintyblends.compat.rrv;
+
+import cc.cassian.rrv.api.TagUtil;
+import cc.cassian.rrv.api.recipe.ReliableServerRecipe;
+import cc.cassian.rrv.api.recipe.ReliableServerRecipeType;
+import io.github.mintynoura.mintyblends.MintyBlends;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public class KettleBrewingServerRecipe implements ReliableServerRecipe {
+
+    private List<Ingredient> ingredients;
+    private ItemStack container;
+    private ItemStack result;
+    private int brewingTime;
+
+
+    public static final ReliableServerRecipeType<KettleBrewingServerRecipe> TYPE = ReliableServerRecipeType.register(Identifier.of(MintyBlends.MOD_ID, "kettle_brewing"),
+            () -> new KettleBrewingServerRecipe(List.of(), ItemStack.EMPTY, ItemStack.EMPTY, 0));
+
+    public KettleBrewingServerRecipe(List<Ingredient> ingredients, ItemStack container, ItemStack result, int brewingTime) {
+        this.ingredients = ingredients;
+        this.container = container;
+        this.result = result;
+        this.brewingTime = brewingTime;
+    }
+
+    public List<Ingredient> getIngredients() {
+        return ingredients;
+    }
+
+    public ItemStack getContainer() {
+        return container;
+    }
+
+    public int getBrewingTime() {
+        return brewingTime;
+    }
+
+    public ItemStack getResult() {
+        return result;
+    }
+
+    @Override
+    public void writeToTag(NbtCompound nbt) {
+        nbt.put("ingredients", TagUtil.writeList(this.ingredients, ((ingredient, nbtCompound) -> TagUtil.writeIngredient(ingredient))));
+        nbt.put("container", TagUtil.encodeItemStackOnServer(this.container));
+        nbt.put("result", TagUtil.encodeItemStackOnServer(this.result));
+        nbt.putInt("brewing_time", this.brewingTime);
+    }
+
+    @Override
+    public void loadFromTag(NbtCompound nbt) {
+        this.ingredients = TagUtil.readList(nbt, "ingredients", TagUtil::readIngredient);
+        this.container = TagUtil.decodeItemStackOnClient(nbt.getCompound("container").orElseGet(NbtCompound::new));
+        this.result = TagUtil.decodeItemStackOnClient(nbt.getCompound("result").orElseGet(NbtCompound::new));
+        this.brewingTime = nbt.getInt("brewing_time", 0);
+    }
+
+    @Override
+    public ReliableServerRecipeType<? extends ReliableServerRecipe> getRecipeType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/io/github/mintynoura/mintyblends/compat/rrv/RrvIntegration.java
+++ b/src/main/java/io/github/mintynoura/mintyblends/compat/rrv/RrvIntegration.java
@@ -1,0 +1,13 @@
+package io.github.mintynoura.mintyblends.compat.rrv;
+
+import cc.cassian.rrv.api.ReliableRecipeViewerPlugin;
+import cc.cassian.rrv.api.recipe.ItemView;
+import cc.cassian.rrv.common.recipe.ServerRecipeManager;
+import io.github.mintynoura.mintyblends.registry.ModRecipes;
+
+public class RrvIntegration implements ReliableRecipeViewerPlugin {
+    @Override
+    public void onIntegrationInitialize() {
+        ItemView.addServerRecipeProvider(list -> ServerRecipeManager.INSTANCE.getRecipesForType(ModRecipes.KETTLE_BREWING_RECIPE_TYPE).forEach(recipe -> list.add(new KettleBrewingServerRecipe(recipe.getIngredients(), recipe.getContainer(), recipe.getResult(), recipe.getBrewingTime()))));
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,9 @@
 		],
 		"eiv": [
 			"io.github.mintynoura.mintyblends.compat.eiv.EivIntegration"
+		],
+		"rrv": [
+			"io.github.mintynoura.mintyblends.compat.rrv.RrvIntegration"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
As you know, RRV is my fork of EIV for 1.21.10 and beyond (I'd link the Modrinth here, but it isn't approved yet). I'm actively working on making improvements to it to better its API, but if you just want a recipe viewer that works with Minty Blends on 1.21.11, here you go! I've opted not to touch the existing EIV integration, as it still has use on 1.21.8 and older versions.

I do want to improve its support for split sources in a future update, but your existing system should remain functional even after that point.